### PR TITLE
chore(repo): scaffold governance baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# All files — default reviewer
+* @Laren-Hagen

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+<!-- One paragraph describing what this PR does and why -->
+
+## Changes
+<!-- Bullet list of what changed -->
+- 
+
+## Testing
+<!-- How was this tested? -->
+- [ ] Manual verification
+- [ ] Unit tests
+
+## Related Issues
+<!-- closes #X, references #Y -->
+
+## Related PRs
+<!-- Links to PRs in other repos if cross-repo change -->
+
+## Checklist
+- [ ] Conventional Commits message format used
+- [ ] Branch pushed to remote before PR creation
+- [ ] All linked objectives/issues closed or explicitly deferred
+- [ ] No direct commits to main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches:
+      - main
+      - 'saga/**'
+      - 'mission/**'
+
+jobs:
+  validate:
+    name: Validate Docker Compose Stack
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate docker-compose syntax
+        run: |
+          # TODO: install docker-compose and run: docker compose config
+          echo "Docker Compose validation — configure in next sprint"
+
+      - name: Check environment template completeness
+        run: |
+          # TODO: diff .env.template keys against .env.example
+          echo "Env template check — configure in next sprint"
+
+      - name: Lint YAML files
+        run: |
+          # TODO: add yamllint or similar
+          echo "YAML linting — configure in next sprint"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,38 @@
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor and IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Environment — NEVER commit secrets
+.env
+.env.local
+.env.*.local
+*.env
+
+# Logs
+*.log
+
+# Docker artifacts
+docker-compose.override.yml
+
+# Python tooling (if scripts added)
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.venv/
+venv/
+
+# Build outputs
+dist/
+build/
+*.tmp
+
+# Ollama model cache (if mounted locally)
+models/
+ollama-data/


### PR DESCRIPTION
## Summary
Adds initial governance and CI baseline to ollama-core. This scaffolds the repository with CODEOWNERS, a Docker-focused .gitignore, a CI workflow skeleton for Docker Compose validation, and the standard PR template.

## Changes
- Added `.github/CODEOWNERS` — @Laren-Hagen as default reviewer
- Added `.gitignore` — Docker + Python tooling defaults, secrets protection
- Added `.github/workflows/ci.yml` — Docker Compose validation skeleton (TODO steps for next sprint)
- Added `.github/PULL_REQUEST_TEMPLATE.md` — standard PR template

## Testing
- [ ] Manual verification

## Related Issues
closes #1

## Checklist
- [x] Conventional Commits message format used
- [x] Branch pushed to remote before PR creation
- [x] No direct commits to main
