### PR TITLE
feat: add Ollama + Open Web UI Docker Compose stack

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,118 @@
+# ═════════════════════════════════════════════════════════════════════════════
+# .env.template — Ollama + Open Web UI Personal Workstation Stack
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# SETUP INSTRUCTIONS:
+#   1. Copy this file to .env:
+#        cp .env.template .env
+#   2. Fill in all REQUIRED values before running `docker compose up -d`.
+#   3. Review OPTIONAL values and tune for your hardware.
+#   4. NEVER commit .env to version control.
+#      It is listed in .gitignore — verify before any `git add`.
+#
+# ⚠️  SECURITY WARNING  ⚠️
+#   WEBUI_SECRET_KEY and WEBUI_ADMIN_PASSWORD contain credentials and
+#   cryptographic key material. Treat them with the same care as passwords.
+#
+#   If either value is accidentally committed to a repository:
+#     WEBUI_SECRET_KEY  — generate a new value with `openssl rand -hex 32`,
+#                         update .env, and recreate the open-webui container.
+#                         All active user sessions will be invalidated.
+#     WEBUI_ADMIN_PASSWORD — change via the Open Web UI admin panel
+#                            (Settings → Admin → Account), then rotate in .env.
+#
+# Sources:
+#   Ollama env vars:      https://docs.ollama.com/faq
+#   Ollama context:       https://docs.ollama.com/context-length
+#   Open Web UI env vars: https://docs.openwebui.com/reference/env-configuration/
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OLLAMA
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Context window in tokens.
+# Default: 8192 — safe on any GPU with ≥ 8 GB VRAM.
+#
+# VRAM impact of increasing this value (llama3.1:8b Q4_K_M, 1 parallel slot):
+#   8192 tokens  → ~1.0 GB KV cache  |  ~6.2 GB total  (safe on 8 GB GPU)
+#   16384 tokens → ~2.0 GB KV cache  |  ~8.5 GB total  (exceeds 8 GB GPU!)
+#   32768 tokens → ~4.0 GB KV cache  |  ~10.5 GB total (requires 12+ GB GPU)
+#
+# In CPU mode the same VRAM figures apply as system RAM requirements.
+# Source: https://docs.ollama.com/context-length
+OLLAMA_CONTEXT_LENGTH=8192
+
+# How long to keep a model loaded in VRAM after the last request.
+#   5m   = unload after 5 minutes of inactivity (default — recommended)
+#   -1   = keep model loaded indefinitely (maximum performance; occupies VRAM)
+#   0    = unload immediately after each response (minimum VRAM use)
+# Source: https://docs.ollama.com/faq — "How do I keep a model loaded in memory?"
+OLLAMA_KEEP_ALIVE=5m
+
+# ── GPU Mode Note ─────────────────────────────────────────────────────────────
+# The docker-compose.yml includes an NVIDIA GPU passthrough block under:
+#   ollama → deploy → resources → reservations → devices
+#
+# If your workstation does NOT have an NVIDIA GPU:
+#   Open docker-compose.yml and REMOVE the entire 'devices:' block.
+#   Ollama will automatically fall back to CPU inference.
+#   No changes to environment variables are needed.
+#
+# See stack-implementation-guide.md → "GPU vs CPU Mode" for full instructions.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OPEN WEB UI
+# Source: https://docs.openwebui.com/reference/env-configuration/
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ⚠️  SECURITY CRITICAL — NEVER COMMIT THIS VALUE TO VERSION CONTROL  ⚠️
+#
+# Secret key used to sign JWTs and encrypt session tokens.
+# REQUIRED — must be set before first run.
+#
+# If this is left empty:
+#   The container auto-generates a key at startup. This key is recreated on
+#   every container recreate (not just restart), invalidating all user sessions
+#   and breaking any OAuth tokens that depend on a stable secret.
+#
+# Generate a secure value with:
+#   openssl rand -hex 32
+#
+# Example (do not copy — generate your own):
+#   WEBUI_SECRET_KEY=a3f2c1d4e5b6789012345678901234567890abcdef1234567890abcdef12345678
+WEBUI_SECRET_KEY=
+
+# Admin account credentials — created automatically on first startup.
+#
+# When WEBUI_ADMIN_EMAIL and WEBUI_ADMIN_PASSWORD are both set, Open Web UI
+# creates the admin account headlessly on first run (no browser interaction
+# required). ENABLE_SIGNUP is automatically disabled after the admin account
+# is created.
+#
+# These values are only used on first startup (when no users exist in the DB).
+# To change the admin password after first run, use the Open Web UI admin panel:
+#   http://localhost:3000 → Settings → Admin → Account
+#
+# REQUIRED — set both or neither.
+# Source: https://docs.openwebui.com/reference/env-configuration/#webui_admin_email
+WEBUI_ADMIN_EMAIL=admin@localhost
+
+# ⚠️  SECURITY CRITICAL — NEVER COMMIT THIS VALUE TO VERSION CONTROL  ⚠️
+#
+# REQUIRED — must be set alongside WEBUI_ADMIN_EMAIL.
+# Use a strong, unique password.
+WEBUI_ADMIN_PASSWORD=
+
+# Internal URL used by Open Web UI to reach the Ollama API.
+# DO NOT change this value if both services are in this Compose stack.
+# 'ollama' is the Docker Compose service name, resolved by internal DNS on
+# ollama-net. Using 'localhost' or '127.0.0.1' here will cause connection
+# failures — inside the container, localhost refers to Open Web UI itself.
+#
+# Source: https://docs.openwebui.com/getting-started/quick-start/
+#         connect-a-provider/starting-with-ollama/#connection-tips
+OLLAMA_BASE_URL=http://ollama:11434

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,293 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Ollama + Open Web UI — Personal Workstation Stack
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Services:
+#   ollama      — LLM inference backend (GPU-optional, NVIDIA passthrough)
+#   open-webui  — Browser-based chat frontend, connected to Ollama
+#
+# Image references:
+#   Ollama:      https://hub.docker.com/r/ollama/ollama
+#   Open Web UI: https://github.com/open-webui/open-webui/pkgs/container/open-webui
+#
+# Security references:
+#   Docker security:     https://docs.docker.com/engine/security/
+#   no-new-privileges:   https://docs.docker.com/reference/compose-file/services/#security_opt
+#   cap_drop / cap_add:  https://docs.docker.com/reference/compose-file/services/#cap_drop
+#   read_only:           https://docs.docker.com/reference/compose-file/services/#read_only
+#   deploy resources:    https://docs.docker.com/compose/compose-file/deploy/
+# ─────────────────────────────────────────────────────────────────────────────
+
+services:
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Ollama — LLM Inference Backend
+  # ───────────────────────────────────────────────────────────────────────────
+  ollama:
+    image: ollama/ollama:0.22.1
+    # Pinned to 0.22.1 (same digest as 'latest' at stack design time, 2026-05-03).
+    # Check https://hub.docker.com/r/ollama/ollama/tags before upgrading.
+    container_name: ollama
+    restart: unless-stopped
+    networks:
+      - ollama-net
+
+    # ── Port policy: 11434 is NOT published to the host. ─────────────────────
+    # Open Web UI reaches Ollama via internal Docker DNS (http://ollama:11434).
+    # Publishing 11434 would expose the unauthenticated Ollama API to any
+    # process on the host. Source: https://docs.ollama.com/faq
+    # (Uncomment the block below ONLY for temporary local debugging.)
+    # ports:
+    #   - "127.0.0.1:11434:11434"    # DEBUG ONLY — exposes unauthenticated API
+
+    volumes:
+      # Named volume persists downloaded models across container recreates.
+      # Source: https://docs.ollama.com/faq — "Where are models stored?"
+      - ollama-models:/root/.ollama/models
+
+    tmpfs:
+      # /root/.ollama — Ollama writes non-model state here (identity keys,
+      # runtime config). Ephemeral storage is acceptable for this data.
+      # The named volume at /root/.ollama/models is mounted on top of this
+      # tmpfs, providing persistent model storage within the ephemeral parent.
+      - /root/.ollama:mode=0755
+      # /tmp — standard transient temp directory for the container process.
+      - /tmp:mode=1777
+
+    environment:
+      # Bind on all container interfaces so Open Web UI (same network) can
+      # reach Ollama by service name. Port 11434 is NOT published to the host.
+      # Source: https://docs.ollama.com/faq
+      OLLAMA_HOST: "0.0.0.0:11434"
+
+      # Context window in tokens. Configurable via .env.
+      # VRAM impact: KV cache grows linearly with context length.
+      #   8192 tokens  → ~1.0 GB KV cache (safe on 8 GB GPU)
+      #   16384 tokens → ~2.0 GB KV cache (total ~8.5 GB — exceeds 8 GB GPU)
+      # Source: https://docs.ollama.com/context-length
+      OLLAMA_CONTEXT_LENGTH: "${OLLAMA_CONTEXT_LENGTH:-8192}"
+
+      # Allow only one model loaded in VRAM at a time.
+      # Prevents silent VRAM exhaustion on model swap.
+      # Source: https://docs.ollama.com/faq
+      OLLAMA_MAX_LOADED_MODELS: "1"
+
+      # One concurrent request — single interactive user, no parallelism needed.
+      # Source: https://docs.ollama.com/faq
+      OLLAMA_NUM_PARALLEL: "1"
+
+      # Minimal request queue for personal non-concurrent use.
+      # Source: https://docs.ollama.com/faq
+      OLLAMA_MAX_QUEUE: "4"
+
+      # Keep model in VRAM for 5 minutes after last request.
+      # Override in .env: "-1" = permanent; "0" = unload immediately after response.
+      # Source: https://docs.ollama.com/faq
+      OLLAMA_KEEP_ALIVE: "${OLLAMA_KEEP_ALIVE:-5m}"
+
+      # Flash Attention reduces KV cache VRAM at 8192+ context lengths.
+      # No inference quality impact. Requires NVIDIA compute capability 5.0+.
+      # Source: https://docs.ollama.com/faq
+      OLLAMA_FLASH_ATTENTION: "1"
+
+      # Explicit model storage path — must match the volume mount point above.
+      # Source: https://docs.ollama.com/faq — "Where are models stored?"
+      OLLAMA_MODELS: "/root/.ollama/models"
+
+    healthcheck:
+      # Ollama's root path returns HTTP 200 when the API server is ready.
+      # start_period: 60s — allow time for GPU initialisation on first start.
+      # Source: https://docs.ollama.com/docker
+      test: ["CMD-SHELL", "curl -sf http://localhost:11434/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+
+    # ── Security hardening ──────────────────────────────────────────────────
+    # Note — running user: Ollama runs as root (uid 0:gid 0) in its official
+    # image. GPU device file access via the NVIDIA Container Runtime requires
+    # this. The risk is mitigated by no-new-privileges, cap_drop: ALL, and
+    # a read-only root filesystem. The NVIDIA Container Runtime injects GPU
+    # device access outside the Linux capabilities framework, so cap_drop: ALL
+    # does not block GPU usage.
+    # Source: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/
+    #         latest/install-guide.html
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+
+    # ── Resource constraints ────────────────────────────────────────────────
+    # Memory limits prevent runaway growth during CPU inference.
+    # In GPU mode, model weights and KV cache reside in VRAM; system RAM
+    # usage drops to < 2 GB. The limits below are safe in both modes.
+    # Increase memory limit if running 13B+ parameter models in CPU mode.
+    # Sources: ollama-config-spec.md, https://docs.docker.com/compose/compose-file/deploy/
+    deploy:
+      resources:
+        limits:
+          memory: "12G"
+          cpus: "8.0"
+        reservations:
+          memory: "8G"
+          cpus: "2.0"
+          # ── NVIDIA GPU Passthrough ──────────────────────────────────────────
+          # REMOVE the entire 'devices:' block below if no NVIDIA GPU is present.
+          # CPU fallback is automatic — no environment variable changes are needed.
+          # Host prerequisites:
+          #   1. NVIDIA driver 531+ installed on the host
+          #   2. NVIDIA Container Toolkit installed
+          #   3. Docker configured for NVIDIA runtime
+          # See stack-implementation-guide.md → GPU vs CPU Mode.
+          # Sources:
+          #   https://docs.ollama.com/docker
+          #   https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/
+          #           latest/install-guide.html
+          #   https://docs.docker.com/compose/compose-file/deploy/#devices
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # Open Web UI — Browser-based Chat Frontend
+  # ───────────────────────────────────────────────────────────────────────────
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:v0.9.2
+    # Pinned to v0.9.2 (latest stable release as of 2026-05-03).
+    # Check https://github.com/open-webui/open-webui/releases before upgrading.
+    # Do NOT use :ollama (bundles Ollama inside — not appropriate for this stack)
+    # or :cuda (Open Web UI itself does not require a GPU).
+    container_name: open-webui
+    restart: unless-stopped
+    networks:
+      - ollama-net
+    ports:
+      # Bound to 127.0.0.1 (localhost only) to prevent other devices on the
+      # local network from reaching the UI. Remove '127.0.0.1:' to enable LAN.
+      # Source: open-web-ui-integration-spec.md — Security Configuration
+      - "127.0.0.1:3000:8080"
+    volumes:
+      # Persists SQLite database (webui.db), user accounts, chat history,
+      # and uploaded files across container recreates.
+      # Source: https://docs.openwebui.com/getting-started/quick-start/
+      #         #2-run-the-container
+      - open-webui-data:/app/backend/data
+    tmpfs:
+      # Python writes transient files to /tmp. PYTHONDONTWRITEBYTECODE=1
+      # (set below) prevents __pycache__ writes to the read-only filesystem.
+      - /tmp:mode=1777
+
+    environment:
+      # ── Ollama Connection ─────────────────────────────────────────────────
+      # MUST use Docker service name 'ollama', NOT 'localhost' or '127.0.0.1'.
+      # Inside the container, 'localhost' refers to Open Web UI itself.
+      # Source: https://docs.openwebui.com/getting-started/quick-start/
+      #         connect-a-provider/starting-with-ollama/#connection-tips
+      OLLAMA_BASE_URL: "${OLLAMA_BASE_URL:-http://ollama:11434}"
+      ENABLE_OLLAMA_API: "True"
+
+      # ── Authentication ────────────────────────────────────────────────────
+      # Source: https://docs.openwebui.com/reference/env-configuration/
+      WEBUI_AUTH: "True"
+      # REQUIRED — see .env.template. If unset, a new key is generated each
+      # container recreate, invalidating all existing user sessions.
+      WEBUI_SECRET_KEY: "${WEBUI_SECRET_KEY}"
+      WEBUI_ADMIN_EMAIL: "${WEBUI_ADMIN_EMAIL}"
+      WEBUI_ADMIN_PASSWORD: "${WEBUI_ADMIN_PASSWORD}"
+      # PersistentConfig: written to DB on first run; persists across restarts.
+      ENABLE_SIGNUP: "False"
+      ENABLE_LOGIN_FORM: "True"
+      JWT_EXPIRES_IN: "24h"
+
+      # ── General Configuration ─────────────────────────────────────────────
+      # 'prod' disables the FastAPI /docs endpoint (security hardening).
+      # Source: https://docs.openwebui.com/reference/env-configuration/#env
+      ENV: "prod"
+      PORT: "8080"
+      # CORS_ALLOW_ORIGIN must be set — avoids WebSocket 'Unexpected token' errors.
+      # Source: https://docs.openwebui.com/reference/env-configuration/#cors_allow_origin
+      CORS_ALLOW_ORIGIN: "http://localhost:3000"
+      # PersistentConfig: used for OAuth callbacks and internal link generation.
+      # Source: https://docs.openwebui.com/reference/env-configuration/#webui_url
+      WEBUI_URL: "http://localhost:3000"
+      ENABLE_OPENAI_API: "False"
+
+      # Prevent Python from writing __pycache__ bytecode to the read-only
+      # root filesystem. Without this, Python silently fails or errors when
+      # attempting to cache compiled bytecode in read-only package directories.
+      PYTHONDONTWRITEBYTECODE: "1"
+
+    healthcheck:
+      # /health returns HTTP 200 when Open Web UI is ready to accept requests.
+      # start_period: 30s accounts for DB initialisation and startup tasks.
+      # Source: https://docs.openwebui.com/getting-started/quick-start/
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+    depends_on:
+      ollama:
+        # Wait for Ollama health check to pass before Open Web UI starts.
+        # Prevents the initial model-list fetch from failing at startup.
+        # Source: open-web-ui-integration-spec.md — Notes for Docker Expert
+        condition: service_healthy
+
+    # ── Security hardening ──────────────────────────────────────────────────
+    # Note — running user: Open Web UI runs as root in its official image.
+    # The upstream project does not publish a supported non-root UID.
+    # The risk is mitigated by no-new-privileges, cap_drop: ALL, read-only
+    # root filesystem, and localhost-only port binding (127.0.0.1:3000:8080).
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+
+    # ── Resource constraints ────────────────────────────────────────────────
+    # 2 GB is sufficient for the base Open Web UI application (SQLite, no RAG).
+    # Increase to 4 GB if RAG or embedding models are enabled.
+    deploy:
+      resources:
+        limits:
+          memory: "2G"
+          cpus: "2.0"
+        reservations:
+          memory: "512M"
+          cpus: "0.5"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Networks
+# ─────────────────────────────────────────────────────────────────────────────
+networks:
+  ollama-net:
+    # Named bridge network provides DNS-based service discovery.
+    # 'ollama' resolves to the Ollama container's IP from within open-webui.
+    # Neither service uses the implicit default Docker bridge network, which
+    # provides no DNS resolution between containers.
+    # Source: https://docs.docker.com/network/drivers/bridge/
+    driver: bridge
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Volumes
+# ─────────────────────────────────────────────────────────────────────────────
+volumes:
+  ollama-models:
+    # Persists downloaded Ollama model files (GGUF weights, manifests, blobs).
+    # Survives container recreates — models are NOT re-downloaded unless pulled.
+    # Source: https://docs.ollama.com/faq — "Where are models stored?"
+    driver: local
+
+  open-webui-data:
+    # Persists Open Web UI application state: SQLite database (webui.db),
+    # user accounts, chat history, and file uploads.
+    # Source: https://docs.openwebui.com/getting-started/quick-start/
+    #         #2-run-the-container
+    driver: local

--- a/stack-implementation-guide.md
+++ b/stack-implementation-guide.md
@@ -1,0 +1,379 @@
+# Stack Implementation Guide: Ollama + Open Web UI
+
+**Stack**: Personal workstation — single-user local deployment  
+**Compose file**: `docker-compose.yml` in this directory  
+**Access URL**: http://localhost:3000
+
+---
+
+## Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Environment Setup](#2-environment-setup)
+3. [GPU vs CPU Mode](#3-gpu-vs-cpu-mode)
+4. [Starting the Stack](#4-starting-the-stack)
+5. [First Model Pull](#5-first-model-pull)
+6. [Verifying the Stack](#6-verifying-the-stack)
+7. [Accessing Open Web UI](#7-accessing-open-web-ui)
+8. [Stopping and Restarting](#8-stopping-and-restarting)
+9. [Configuration Reference](#9-configuration-reference)
+10. [Non-Obvious Design Decisions](#10-non-obvious-design-decisions)
+
+---
+
+## 1. Prerequisites
+
+### Required
+
+| Requirement | Minimum Version | Notes |
+|-------------|----------------|-------|
+| Docker Engine | 24.0+ | Compose Spec `deploy.resources` requires Docker Compose v2. Check: `docker compose version` |
+| Docker Compose | v2.20+ (bundled with Docker Desktop 4.22+) | Standalone Compose v1 (`docker-compose`) is not supported |
+| Available RAM | 8 GB free (CPU mode) or 2 GB free (GPU mode) | Ollama uses VRAM in GPU mode; system RAM is minimal |
+| Available disk | 10 GB+ | Varies by model. `llama3.1:8b` (Q4_K_M) requires ~5.5 GB |
+
+### Required for NVIDIA GPU Mode (optional)
+
+| Requirement | Notes | Source |
+|-------------|-------|--------|
+| NVIDIA driver 531+ | Check: `nvidia-smi` | [NVIDIA driver install](https://www.nvidia.com/Download/index.aspx) |
+| NVIDIA Container Toolkit | Enables GPU passthrough to Docker containers | [Install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) |
+| Docker configured for NVIDIA runtime | Run after toolkit install | See GPU setup steps below |
+
+**GPU prerequisites — setup commands (Linux):**
+
+```bash
+# Install NVIDIA Container Toolkit
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+  | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+
+curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+  | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+  | sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+sudo apt-get update && sudo apt-get install -y nvidia-container-toolkit
+
+# Configure Docker to use the NVIDIA runtime
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Verify
+docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi
+```
+
+Sources:
+- [NVIDIA Container Toolkit — Install Guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+- [Ollama Docker — NVIDIA GPU](https://docs.ollama.com/docker)
+
+---
+
+## 2. Environment Setup
+
+Before starting the stack, copy the template and fill in the required values:
+
+```bash
+# Step 1: Copy the template
+cp .env.template .env
+
+# Step 2: Open .env in your editor
+#   Fill in the three REQUIRED values:
+#     WEBUI_SECRET_KEY     — generate with: openssl rand -hex 32
+#     WEBUI_ADMIN_EMAIL    — your admin login email (e.g., admin@localhost)
+#     WEBUI_ADMIN_PASSWORD — a strong password for the admin account
+```
+
+**Generating `WEBUI_SECRET_KEY`:**
+
+```bash
+openssl rand -hex 32
+# Example output: a3f2c1d4e5b6789012345678901234567890abcdef1234567890abcdef12345678
+# Copy the output into .env as the value for WEBUI_SECRET_KEY
+```
+
+**Why `WEBUI_SECRET_KEY` is mandatory:**  
+Open Web UI uses this key to sign JWTs (session tokens). If the key is not set, the container auto-generates one at startup. The auto-generated key is created fresh on every container **recreate** (not just restart), which invalidates all active user sessions. Setting it explicitly in `.env` keeps sessions stable across recreates. Source: [Open Web UI env config — WEBUI_SECRET_KEY](https://docs.openwebui.com/reference/env-configuration/#webui_secret_key)
+
+**`.env` security checklist before starting:**
+
+- [ ] `WEBUI_SECRET_KEY` is set to a 64-character hex string (output of `openssl rand -hex 32`)
+- [ ] `WEBUI_ADMIN_EMAIL` is set
+- [ ] `WEBUI_ADMIN_PASSWORD` is set to a strong, unique password
+- [ ] `.env` is listed in `.gitignore` — verify with `git check-ignore -v .env`
+- [ ] You have NOT committed `.env` to any branch
+
+---
+
+## 3. GPU vs CPU Mode
+
+### GPU Mode (default — requires NVIDIA GPU + Container Toolkit)
+
+The `docker-compose.yml` includes an NVIDIA GPU passthrough block by default:
+
+```yaml
+# In docker-compose.yml — ollama service — deploy.resources.reservations:
+devices:
+  - driver: nvidia
+    count: all
+    capabilities: [gpu]
+```
+
+This is already in place. If the NVIDIA Container Toolkit is installed and the host has a compatible GPU, Ollama will use the GPU automatically with no further changes.
+
+**Minimum GPU**: 8 GB VRAM (RTX 3060 12 GB, RTX 3070, RTX 4060, or equivalent).  
+The default 8192 token context with `llama3.1:8b` Q4_K_M requires ~6.2 GB VRAM.
+
+**Verifying GPU is in use after startup:**
+
+```bash
+docker exec -it ollama ollama ps
+# Look for: PROCESSOR column showing "100% GPU"
+```
+
+### CPU Mode (no NVIDIA GPU)
+
+1. Open `docker-compose.yml`
+2. Find the `devices:` block under `ollama → deploy → resources → reservations`
+3. **Remove** the entire `devices:` section (approximately 8 lines):
+
+   ```yaml
+   # DELETE these lines for CPU mode:
+         devices:
+           - driver: nvidia
+             count: all
+             capabilities: [gpu]
+   ```
+
+4. Save the file. No environment variable changes are needed.
+
+Ollama detects the absence of a compatible GPU and falls back to CPU inference automatically.
+
+**CPU mode performance expectations** (approximate, varies by hardware):
+
+| Hardware | Throughput | Notes |
+|----------|-----------|-------|
+| Modern desktop CPU (Ryzen 7 / Core i7) | 6–12 tok/s | With llama3.1:8b Q4_K_M |
+| Laptop CPU (Ryzen 5 / Core i5) | 3–7 tok/s | Slower, but functional |
+| RAM requirement | 8 GB free | Model weights load into system RAM instead of VRAM |
+
+**Verifying CPU mode after startup:**
+
+```bash
+docker exec -it ollama ollama ps
+# Look for: PROCESSOR column showing "100% CPU"
+```
+
+Source: [Ollama Docker — CPU and GPU](https://docs.ollama.com/docker)
+
+---
+
+## 4. Starting the Stack
+
+```bash
+# From the ollama-core/ directory:
+
+# Pull images and start all services in detached mode
+docker compose up -d
+
+# Follow logs to confirm both services start cleanly
+docker compose logs -f
+
+# Check service health status
+docker compose ps
+```
+
+Expected output from `docker compose ps` when healthy:
+
+```
+NAME          IMAGE                                    STATUS
+ollama        ollama/ollama:0.22.1                     Up X minutes (healthy)
+open-webui    ghcr.io/open-webui/open-webui:v0.9.2    Up X minutes (healthy)
+```
+
+Open Web UI will not reach `(healthy)` until Ollama is `(healthy)` first, because of the `depends_on: condition: service_healthy` dependency. This is expected. Both services should be healthy within 2–3 minutes of first start.
+
+---
+
+## 5. First Model Pull
+
+The Ollama container starts without any models. Pull a model before using Open Web UI:
+
+```bash
+# Pull llama3.1:8b (Q4_K_M quantization, ~5.5 GB download)
+# This is a capable general-purpose 8B chat model suitable for this stack.
+docker exec -it ollama ollama pull llama3.1:8b
+
+# Alternative: smaller model for limited resources
+docker exec -it ollama ollama pull llama3.2:3b    # ~2.0 GB, faster on CPU
+
+# List pulled models
+docker exec ollama ollama list
+```
+
+**Note:** `llama3.1:8b` is the correct Ollama tag for Meta's Llama 3.1 8B parameter model. The `llama3.2` family contains 1B, 3B, and 11B (vision) sizes — there is no 8B variant in that release. Source: [Ollama model library](https://ollama.com/library)
+
+**After pulling a model:**
+- Return to http://localhost:3000
+- Select the model from the model selector in the top-left of the chat interface
+- Models pulled into Ollama appear automatically; no restart is required
+
+---
+
+## 6. Verifying the Stack
+
+### Ollama API
+
+```bash
+# Confirm the Ollama API is responding (from the host — if port is published for debug)
+curl http://localhost:11434/api/version
+
+# Confirm Open Web UI can reach Ollama via internal Docker DNS
+docker exec open-webui curl -sf http://ollama:11434/api/version
+# Expected: {"version":"0.22.1"} (or similar JSON)
+```
+
+### Open Web UI
+
+```bash
+# Check health endpoint
+curl http://localhost:3000/health
+# Expected: {"status":"ok"} or HTTP 200
+
+# Check service health from Docker
+docker compose ps
+# Both services should show (healthy)
+```
+
+### Volume persistence test
+
+```bash
+# Recreate the stack (simulates upgrade or restart scenario)
+docker compose down
+docker compose up -d
+
+# After both services are healthy:
+# 1. Browse to http://localhost:3000
+# 2. Your admin account should still exist (DB persisted via open-webui-data volume)
+# 3. Models should still be listed (persisted via ollama-models volume)
+# 4. Your existing session should remain valid (WEBUI_SECRET_KEY was stable)
+```
+
+Source: [Open Web UI integration spec — Verification Checklist](../mission-command/missions/147-stack-design-and-implementation/deliverables/open-web-ui-integration-spec.md)
+
+---
+
+## 7. Accessing Open Web UI
+
+| URL | Notes |
+|-----|-------|
+| http://localhost:3000 | Primary browser access point |
+| http://localhost:3000/health | Health check endpoint |
+
+The UI is bound to `127.0.0.1:3000` — accessible only from the local machine.  
+To allow LAN access (other devices on your network), change the port mapping in `docker-compose.yml` from `"127.0.0.1:3000:8080"` to `"3000:8080"` and restart the stack.
+
+**First login:**
+- Email: the value you set for `WEBUI_ADMIN_EMAIL` in `.env`
+- Password: the value you set for `WEBUI_ADMIN_PASSWORD` in `.env`
+
+---
+
+## 8. Stopping and Restarting
+
+```bash
+# Stop services (containers removed, volumes preserved)
+docker compose down
+
+# Stop and remove volumes — DESTRUCTIVE: deletes all models and chat history
+# docker compose down -v    # DO NOT RUN unless you intend to wipe all data
+
+# Restart a single service
+docker compose restart ollama
+docker compose restart open-webui
+
+# View live logs
+docker compose logs -f
+docker compose logs -f ollama
+docker compose logs -f open-webui
+```
+
+---
+
+## 9. Configuration Reference
+
+All tunable settings are in `.env`. The most commonly adjusted values:
+
+| Variable | Default | When to change |
+|----------|---------|----------------|
+| `OLLAMA_CONTEXT_LENGTH` | `8192` | Increase for longer conversations; requires more VRAM/RAM |
+| `OLLAMA_KEEP_ALIVE` | `5m` | Set `-1` to keep model permanently loaded; `0` to free VRAM immediately |
+| `WEBUI_SECRET_KEY` | *(must be set)* | Rotate if accidentally exposed |
+| `WEBUI_ADMIN_PASSWORD` | *(must be set)* | Change via UI after first login for better security hygiene |
+
+After changing `.env`, restart the affected service:
+
+```bash
+docker compose up -d --force-recreate ollama       # for Ollama env changes
+docker compose up -d --force-recreate open-webui   # for Open Web UI env changes
+```
+
+---
+
+## 10. Non-Obvious Design Decisions
+
+### Why Ollama's port 11434 is not published to the host
+
+`OLLAMA_HOST=0.0.0.0:11434` binds the Ollama API server to all container network interfaces so that Open Web UI (a sibling container on the same `ollama-net` bridge) can reach it by service name (`http://ollama:11434`). Binding to `0.0.0.0` inside the container is required for this internal DNS-based routing to work.
+
+Critically, this does **not** expose the port to the host machine. Port 11434 is not in the `ports:` block, so it is only reachable from within `ollama-net`. Publishing 11434 to the host would expose the unauthenticated Ollama API (no API key required by default) to any process on the host machine.
+
+Source: [Ollama FAQ — How can I expose Ollama on my network?](https://docs.ollama.com/faq)
+
+### Why `OLLAMA_BASE_URL` must use the service name, not localhost
+
+Inside the Open Web UI container, `localhost` and `127.0.0.1` refer to the Open Web UI container's own loopback interface — not the host machine, and not the Ollama container. Using `http://ollama:11434` relies on Docker's internal DNS resolution, which maps the service name `ollama` to the Ollama container's IP address within `ollama-net`.
+
+Source: [Open Web UI — Connection Tips](https://docs.openwebui.com/getting-started/quick-start/connect-a-provider/starting-with-ollama/#connection-tips)
+
+### Why `read_only: true` is combined with `tmpfs` and named volumes
+
+Both services run with `read_only: true` (read-only root filesystem). Docker volume mounts — both named volumes and `tmpfs` entries — are applied on top of the read-only root filesystem and are independently writable.
+
+**Ollama** has two writable mount points:
+- `tmpfs` at `/root/.ollama` — ephemeral, for Ollama non-model state (identity keys, runtime config)
+- Named volume `ollama-models` at `/root/.ollama/models` — persistent, for model weights
+
+The named volume is mounted as a child of the tmpfs. This creates a stacked mount: writes to `/root/.ollama/` (non-models) go to the tmpfs (ephemeral); writes to `/root/.ollama/models/` go to the named volume (persistent). Ollama non-model state (identity keys) does not need to persist for this single-container stack.
+
+**Open Web UI** has:
+- `tmpfs` at `/tmp` — for transient Python temp files
+- Named volume `open-webui-data` at `/app/backend/data` — persistent, for SQLite DB and uploads
+- `PYTHONDONTWRITEBYTECODE=1` — prevents Python from attempting to write `__pycache__` bytecode to the read-only package directories
+
+### Why `ENABLE_SIGNUP=False` even though `WEBUI_ADMIN_EMAIL`/`WEBUI_ADMIN_PASSWORD` disables it automatically
+
+`WEBUI_ADMIN_EMAIL` + `WEBUI_ADMIN_PASSWORD` disable signup automatically after the admin account is created on first run. However, `ENABLE_SIGNUP` is a `PersistentConfig` variable — once written to the database it persists across container restarts. Setting it explicitly to `False` in the environment provides a persistent, documented lock that is visible in the compose configuration.
+
+Source: [Open Web UI env config — ENABLE_SIGNUP](https://docs.openwebui.com/reference/env-configuration/#enable_signup)
+
+### Why resource `reservations` are set alongside `limits`
+
+`deploy.resources.reservations` documents the minimum resources the container needs to start and function. On a workstation with limited free memory, Docker will refuse to schedule the container if reservations cannot be satisfied, giving a clear error rather than an OOM kill after startup. The Ollama reservation of 8 GB RAM ensures the container starts only when adequate system RAM is available for CPU-mode inference.
+
+Source: [Docker Compose — deploy.resources](https://docs.docker.com/compose/compose-file/deploy/)
+
+### If you enable RAG or embedding features in Open Web UI
+
+Open Web UI downloads sentence-transformer embedding models to `~/.cache` at runtime when RAG features are enabled. These models are re-downloaded on every container recreate because `/root/.cache` is not backed by a named volume. To persist embedding models, add a named volume entry:
+
+```yaml
+# In docker-compose.yml — open-webui service:
+volumes:
+  - open-webui-data:/app/backend/data
+  - open-webui-cache:/root/.cache    # add this line
+
+# In the top-level volumes: block:
+  open-webui-cache:
+    driver: local
+```
+
+This is not included in the default configuration because RAG is not part of this stack's initial scope and the additional volume adds complexity.


### PR DESCRIPTION
## Summary
Adds a production-ready Docker Compose stack for Ollama + Open Web UI to the ollama-core repository. The stack includes GPU passthrough with CPU fallback, health checks, security hardening, named volumes for data persistence, and an isolated bridge network.

## Changes
- \docker-compose.yml\ — complete Ollama + Open Web UI services with health checks, resource constraints, and security hardening
- \.env.template\ — all environment variables with documentation and sensible defaults
- \stack-implementation-guide.md\ — startup guide covering GPU/CPU modes, first model pull, and operational notes

## Testing
- [ ] Manual verification — stack starts cleanly with \docker compose up -d\
- [ ] GPU mode verified with \
vidia-smi\ pass-through
- [ ] CPU fallback verified without GPU

## Related Issues
closes #3

## Related PRs
- mission-command: mission/147-stack-design-and-implementation → saga/146-ollama-and-open-web-ui-delivery (see cross-repo PR for mission-command)

## Checklist
- [x] Conventional Commits message format used
- [x] Branch pushed to remote before PR creation
- [x] All linked objectives/issues closed or explicitly deferred
- [x] No direct commits to main