### PR TITLE
chore: upgrade Ollama from 0.22.1 to 0.23.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,8 @@ services:
   # Ollama — LLM Inference Backend
   # ───────────────────────────────────────────────────────────────────────────
   ollama:
-    image: ollama/ollama:0.22.1
-    # Pinned to 0.22.1 (same digest as 'latest' at stack design time, 2026-05-03).
+    image: ollama/ollama:0.23.0
+    # Pinned to 0.23.0 (latest stable release as of 2026-05-03).
     # Check https://hub.docker.com/r/ollama/ollama/tags before upgrading.
     container_name: ollama
     restart: unless-stopped


### PR DESCRIPTION
closes #5

Updates Ollama image pin from 0.22.1 to 0.23.0 (released 2026-05-03 on Docker Hub). Required to support gemma4:e2b model which fails on older versions. Open Web UI remains at v0.9.2 (no change).
